### PR TITLE
Fix buffer overflow vulnerability in pcnet.c

### DIFF
--- a/qemu_mode/qemu-2.10.0/hw/net/pcnet.c
+++ b/qemu_mode/qemu-2.10.0/hw/net/pcnet.c
@@ -1007,14 +1007,14 @@ ssize_t pcnet_receive(NetClientState *nc, const uint8_t *buf, size_t size_)
     uint8_t buf1[60];
     int remaining;
     int crc_err = 0;
-    int size = size_;
+    size_t size = size_;
 
     if (CSR_DRX(s) || CSR_STOP(s) || CSR_SPND(s) || !size ||
         (CSR_LOOP(s) && !s->looptest)) {
         return -1;
     }
 #ifdef PCNET_DEBUG
-    printf("pcnet_receive size=%d\n", size);
+    printf("pcnet_receive size=%zu\n", size);
 #endif
 
     /* if too small buffer, then expand it */


### PR DESCRIPTION
I'm Braden, a CS student at the University of Tennessee, Knoxville, and am completing an Open Source contribution project for my software development class. 

Your project is using an older version of qemu that has a buffer overflow vulnerability related to the size variable used in pcnet.c. Since it is an int, if the size_ variable is larger than INT_MAX, there will be a negative value for size, which can be used to access data out of bounds of buf and buf1. To eliminate this vulnerability, I just changed the int size variable to type size_t, which prevents the type conversion that allows for the potential buffer overflow.